### PR TITLE
Bug: clouddeploy.yaml gets empty after running bootstrap/init.sh

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,7 +2,7 @@
 
 {% block content %} 
 
-    <div class="alert alert-success">Population estimates for <strong>{{county}}</strong></div>
+    <div class="alert alert-success"><h1>Population estimates for <strong>{{county}}</strong></h1></div>
 
     <table class="table table-striped">
     <thead>

--- a/bootstrap/gke-cluster-init.sh
+++ b/bootstrap/gke-cluster-init.sh
@@ -7,20 +7,20 @@ if [[ -z "${PROJECT_ID}" ]]; then
 fi
 # Test cluster
 echo "creating testcluster..."
-gcloud beta container --project "$PROJECT_ID" clusters create-auto "testcluster" \
---region "us-central1" --release-channel "regular" --network "projects/$PROJECT_ID/global/networks/default" \
---subnetwork "projects/$PROJECT_ID/regions/us-central1/subnetworks/default" \
+gcloud beta container --project "$PROJECT_ID" clusters create-auto "test-cluster" \
+--region "us-central1" --release-channel "regular" --network "projects/$PROJECT_ID/global/networks/k8s-vpc" \
+--subnetwork "projects/$PROJECT_ID/regions/us-central1/subnetworks/k8s-subnet" \
 --cluster-ipv4-cidr "/17" --services-ipv4-cidr "/22" --async
 # Staging cluster
 echo "creating stagingcluster..."
-gcloud beta container --project "$PROJECT_ID" clusters create-auto "stagingcluster" \
---region "us-central1" --release-channel "regular" --network "projects/$PROJECT_ID/global/networks/default" \
---subnetwork "projects/$PROJECT_ID/regions/us-central1/subnetworks/default" \
+gcloud beta container --project "$PROJECT_ID" clusters create-auto "staging-cluster" \
+--region "us-central1" --release-channel "regular" --network "projects/$PROJECT_ID/global/networks/k8s-vpc" \
+--subnetwork "projects/$PROJECT_ID/regions/us-central1/subnetworks/k8s-subnet" \
 --cluster-ipv4-cidr "/17" --services-ipv4-cidr "/22" --async
 # Prod cluster
 echo "creating prodcluster..."
-gcloud beta container --project "$PROJECT_ID" clusters create-auto "prodcluster" \
---region "us-central1" --release-channel "regular" --network "projects/$PROJECT_ID/global/networks/default" \
---subnetwork "projects/$PROJECT_ID/regions/us-central1/subnetworks/default" \
+gcloud beta container --project "$PROJECT_ID" clusters create-auto "prod-cluster" \
+--region "us-central1" --release-channel "regular" --network "projects/$PROJECT_ID/global/networks/k8s-vpc" \
+--subnetwork "projects/$PROJECT_ID/regions/us-central1/subnetworks/k8s-subnet" \
 --cluster-ipv4-cidr "/17" --services-ipv4-cidr "/22" --async
 echo "Creating clusters! Check the UI for progress"

--- a/bootstrap/init.sh
+++ b/bootstrap/init.sh
@@ -24,7 +24,7 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 gcloud artifacts repositories create pop-stats --location=us-central1 \
 --repository-format=docker
 # customize the clouddeploy.yaml 
-sed -e "s/project-id-here/${PROJECT_ID}/" clouddeploy.yaml > clouddeploy.yaml
+sed -i "s/project-id-here/${PROJECT_ID}/g" clouddeploy.yaml
 # creates the Google Cloud Deploy pipeline
 gcloud deploy apply --file clouddeploy.yaml \
 --region=us-central1 --project=$PROJECT_ID

--- a/clouddeploy.yaml
+++ b/clouddeploy.yaml
@@ -1,4 +1,4 @@
-# replace "project-id-here" in the three targets below with your actual project(s)
+# replace "cloud-deploy-356220" in the three targets below with your actual project(s)
 apiVersion: deploy.cloud.google.com/v1
 kind: DeliveryPipeline
 metadata:
@@ -21,7 +21,7 @@ metadata:
   name: test
 description: test cluster
 gke:
-  cluster: projects/project-id-here/locations/us-central1/clusters/testcluster
+  cluster: projects/cloud-deploy-356220/locations/us-central1/clusters/test-cluster
 ---
 
 apiVersion: deploy.cloud.google.com/v1
@@ -30,7 +30,7 @@ metadata:
   name: staging
 description: staging cluster
 gke:
-  cluster: projects/project-id-here/locations/us-central1/clusters/stagingcluster
+  cluster: projects/cloud-deploy-356220/locations/us-central1/clusters/staging-cluster
 ---
 
 apiVersion: deploy.cloud.google.com/v1
@@ -40,4 +40,4 @@ metadata:
 description: prod cluster
 requireApproval: true
 gke:
-  cluster: projects/project-id-here/locations/us-central1/clusters/prodcluster
+  cluster: projects/cloud-deploy-356220/locations/us-central1/clusters/prod-cluster


### PR DESCRIPTION
Fixed issue with 'sed' usage in init.sh that was overwriting clouddeploy.yaml file and producing and empty file.